### PR TITLE
Resolve Vercel 404 error

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -68,7 +68,7 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(import.meta.dirname, "public");
+  const distPath = path.resolve(import.meta.dirname, "..", "dist", "public");
 
   if (!fs.existsSync(distPath)) {
     throw new Error(

--- a/vercel.json
+++ b/vercel.json
@@ -2,23 +2,28 @@
   "version": 2,
   "builds": [
     {
-      "src": "server/**/*.ts",
-      "use": "@vercel/node"
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist/public"
+      }
     },
     {
-      "src": "client/package.json",
-      "use": "@vercel/static-build",
-      "config": { "distDir": "../dist/public" }
+      "src": "server/index.ts",
+      "use": "@vercel/node"
     }
   ],
   "routes": [
     {
+      "handle": "filesystem"
+    },
+    {
       "src": "/api/(.*)",
-      "dest": "/server/$1.ts"
+      "dest": "/server/index.ts"
     },
     {
       "src": "/(.*)",
-      "dest": "/dist/public/$1"
+      "dest": "/dist/public/index.html"
     }
   ]
 } 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated Vercel configuration and static file path to fix 404 errors when deploying the app.

- **Dependencies**
  - Changed vercel.json to use static build for the frontend and updated server routing.
  - Adjusted static file path in server/vite.ts to match new build output.

<!-- End of auto-generated description by cubic. -->

